### PR TITLE
Correct coverlet entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The CLI also supports an older format called "project tools" or `<DotNetCliToolR
 Command           | Package Id | Author | Description
 ------------------|------------|--------|--------------
 `certes` | [dotnet-certes](https://www.nuget.org/packages/dotnet-certes/) | [@fszlin](https://github.com/fszlin) | CLI tool for acquire certificates via the Automated Certificate Management Environment (ACME) protocol (example: LetsEncrypt.org)  [GitHub](https://github.com/fszlin/certes)
-`coverlet.console` | [coverlet](https://github.com/tonerdo/coverlet) | [@tonerdo](https://github.com/tonerdo) | Coverlet is a cross platform code coverage library for .NET Core, with support for line, branch and method coverage. [GitHub](https://github.com/tonerdo/coverlet)
+`coverlet` | [coverlet.console](https://www.nuget.org/packages/coverlet.console/) | [@tonerdo](https://github.com/tonerdo) | Coverlet is a cross platform code coverage library for .NET Core, with support for line, branch and method coverage. [GitHub](https://github.com/tonerdo/coverlet)
 `csproj-to-2017` | [Project2015To2017.Cli](https://www.nuget.org/packages/Project2015To2017.Cli/) | [@hvanbakel](https://github.com/hvanbakel) | CLI tool for converting old csproj files to the new VS2017 csproj format  [GitHub](https://github.com/hvanbakel/CsprojToVs2017)
 `dmd5` | [dmd5](https://www.nuget.org/packages/dmd5) | [@Rwing](https://github.com/Rwing) | Just generate MD5 hash value in CLI.  [GitHub](https://github.com/Rwing/Dotnet.Tool.MD5)
 `docker-watch` | [docker-watch](https://www.nuget.org/packages/docker-watch) | [@nickvdyck](https://github.com/nickvdyck) | A command line utiltiy to notify docker mounted volumes about changes on Windows.  [GitHub](https://github.com/nickvdyck/docker-watch)


### PR DESCRIPTION
This PR corrects the following issues with the Coverlet entry:

1. The command name
1. The package ID
1. Links to the NuGet package instead of GitHub 