### PR TITLE
add base64urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ A list of tool extensions for .NET Core Command Line (dotnet CLI), aka '.NET Cor
       </td>
     </tr>
     <tr>
+      <td><code>base64urls </code></td>
+      <td>
+        <p>
+          CLI tool for base64 & base64url encode/decode for URL applications.
+        </p>
+        <p>
+          <strong>Project site:</strong> <a href="https://github.com/guitarrapc/Base64UrlCore">GitHub</a>
+          <br />
+          <strong>Author:</strong> <a href="https://github.com/guitarrapc">@guitarrapc</a>
+        </p>
+        <code>dotnet tool install -g <a href="https://www.nuget.org/packages/base64urls/">base64urls</a></code>
+      </td>
+    </tr>
+    <tr>
       <td><code>certes</code></td>
       <td>
         <p>


### PR DESCRIPTION
Hi, This is a PR to add a link to the .NET Global tool [base64urls](https://www.nuget.org/packages/base64urls/).

This tool offers similar experience as npm [base64\-url\-cli](https://www.npmjs.com/package/base64-url-cli) offers.

Thanks.