### PR TITLE
dotnet-xdt: add netstandard library/net461 executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -819,8 +819,9 @@ A list of tool extensions for .NET Core Command Line (dotnet CLI), aka '.NET Cor
       <td><code>dotnet-xdt</code></td>
       <td>
         <p>
-          Global tool for applying XML Document Transformations to .NET configuration files, or any other
-          XML-structured content.
+          Toolbox for applying XML Document Transformations to .NET configuration files, or any other
+          XML-structured content. Includes a .NET Core global tool, a .NET Standard library with no
+          external dependencies, and a standalone .NET 4.6+ executable.
         </p>
         <p>
           <strong>Project site:</strong> <a href="https://github.com/nil4/dotnet-transform-xdt">GitHub</a>


### PR DESCRIPTION
As of https://github.com/nil4/dotnet-transform-xdt/releases/tag/v2.1.0, in addition to the `dotnet-xdt` global tool, a couple more options are available:
- a .NET Standard 2.0 library, with no external dependencies, for custom XDT transformations
- a standalone executable, for .NET 4.6.1 or later, for automation on Windows PCs without .NET Core

Update README to reflect these new options.