### PR TITLE
Add snitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1862,20 +1862,6 @@ A list of tool extensions for .NET Core Command Line (dotnet CLI), aka '.NET Cor
         <code>dotnet tool install -g <a href="https://www.nuget.org/packages/SharpFuzz.CommandLine/">SharpFuzz.CommandLine</a></code>
       </td>
     </tr>
-		<tr>
-      <td><code>snitch</code></td>
-      <td>
-        <p>
-          A tool that help you find transitive package references that can be removed.
-        </p>
-        <p>
-					<strong>Project site:</strong> <a href="https://github.com/spectresystems/snitch">GitHub</a>
-          <br />
-          <strong>Author:</strong> <a href="https://github.com/spectresystems">@Spectre Systems AB</a>
-        </p>
-        <code>dotnet tool install -g <a href="https://www.nuget.org/packages/Snitch/">Snitch</a></code>
-      </td>
-    </tr>
     <tr>
       <td><code>sleet</code></td>
       <td>
@@ -1888,6 +1874,20 @@ A list of tool extensions for .NET Core Command Line (dotnet CLI), aka '.NET Cor
           <strong>Author:</strong> <a href="https://github.com/emgarten">@emgarten</a>
         </p>
         <code>dotnet tool install -g <a href="https://www.nuget.org/packages/Sleet/">Sleet</a></code>
+      </td>
+    </tr>
+    <tr>
+      <td><code>snitch</code></td>
+      <td>
+        <p>
+          A tool that help you find transitive package references that can be removed.
+        </p>
+        <p>
+          <strong>Project site:</strong> <a href="https://github.com/spectresystems/snitch">GitHub</a>
+          <br />
+          <strong>Author:</strong> <a href="https://github.com/spectresystems">@Spectre Systems AB</a>
+        </p>
+        <code>dotnet tool install -g <a href="https://www.nuget.org/packages/Snitch/">Snitch</a></code>
       </td>
     </tr>
     <tr>

--- a/README.md
+++ b/README.md
@@ -1862,6 +1862,20 @@ A list of tool extensions for .NET Core Command Line (dotnet CLI), aka '.NET Cor
         <code>dotnet tool install -g <a href="https://www.nuget.org/packages/SharpFuzz.CommandLine/">SharpFuzz.CommandLine</a></code>
       </td>
     </tr>
+		<tr>
+      <td><code>snitch</code></td>
+      <td>
+        <p>
+          A tool that help you find transitive package references that can be removed.
+        </p>
+        <p>
+					<strong>Project site:</strong> <a href="https://github.com/spectresystems/snitch">GitHub</a>
+          <br />
+          <strong>Author:</strong> <a href="https://github.com/spectresystems">@Spectre Systems AB</a>
+        </p>
+        <code>dotnet tool install -g <a href="https://www.nuget.org/packages/Snitch/">Snitch</a></code>
+      </td>
+    </tr>
     <tr>
       <td><code>sleet</code></td>
       <td>


### PR DESCRIPTION
Snitch A tool that help you find transitive package references that can be removed.
(sorted now)