### PR TITLE
Updated Azure API Management install line

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ A list of tool extensions for .NET Core Command Line (dotnet CLI), aka '.NET Cor
           <br />
           <strong>Author:</strong> <a href="https://github.com/mirsaeedi/">@mirsaeedi</a>
         </p>
-        <code>dotnet tool install -g <a href="https://www.nuget.org/packages/Apim.DevOps.Toolkit/">dotnet-apim</a></code>
+        <code>dotnet tool install -g <a href="https://www.nuget.org/packages/Apim.DevOps.Toolkit/">Apim.DevOps.Toolkit</a></code>
       </td>
     </tr>	  
     <tr>


### PR DESCRIPTION
Updated Azure API management install line to match the one specified on https://github.com/mirsaeedi/dotnet-apim.