### PR TITLE
Add exceldna-unpack dotnet tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1165,6 +1165,20 @@ A list of tool extensions for .NET Core Command Line (dotnet CLI), aka '.NET Cor
       </td>
     </tr>
     <tr>
+      <td><code>exceldna-unpack</code></td>
+      <td>
+        <p>
+          Extract (unpack) the contents of Excel-DNA add-ins that have been packed with ExcelDnaPack, including .NET assemblies
+        </p>
+        <p>
+          <strong>Project site:</strong> <a href="https://github.com/augustoproiete/exceldna-unpack">GitHub</a>
+          <br />
+          <strong>Author:</strong> <a href="https://github.com/augustoproiete">@augustoproiete</a>
+        </p>
+        <code>dotnet tool install -g <a href="https://www.nuget.org/packages/exceldna-unpack/">exceldna-unpack</a></code>
+      </td>
+    </tr>
+    <tr>
       <td><code>execute</code></td>
       <td>
         <p>


### PR DESCRIPTION
Microsoft Excel Add-Ins developed with [Excel-DNA](https://github.com/Excel-DNA) are usually packaged up into a single `.xll` file for easier distribution. The `.xll` file contains all the components necessary to run the add-in, which usually include one or more .NET assemblies along with other resources the add-in uses such as images, ribbon `.xml` definitions and other configuration files.

[ExcelDna-Unpack](https://github.com/augustoproiete/exceldna-unpack) allows users to extract the resources of these packaged `.xll`