### PR TITLE
Adds dotnet-todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1255,8 +1255,8 @@ The following list was created by users like you. Feel free to add yours. The pr
       <td>
         <p>
           Manage your todo list using the command line syntax and text file format of 
-		  <a href-"http://todotxt.org/">http://todotxt.org/</a>. This port tries to remain faithful to the 
-		  command line and functionality of the original shell script wherever possible.
+          <a href-"http://todotxt.org/">http://todotxt.org/</a>. This port tries to remain faithful to the 
+          command line and functionality of the original shell script wherever possible.
         </p>
         <p>
           <strong>Project site:</strong> <a href="https://github.com/rprouse/dotnet-todo">GitHub</a>

--- a/README.md
+++ b/README.md
@@ -1254,7 +1254,8 @@ The following list was created by users like you. Feel free to add yours. The pr
       <td><code>dotnet-todo</code></td>
       <td>
         <p>
-          A .NET port of <a href-"http://todotxt.org/">http://todotxt.org/</a> that tries to remain faithful to the 
+          Manage your todo list using the command line syntax and text file format of 
+		  <a href-"http://todotxt.org/">http://todotxt.org/</a>. This port tries to remain faithful to the 
 		  command line and functionality of the original shell script wherever possible.
         </p>
         <p>

--- a/README.md
+++ b/README.md
@@ -1251,6 +1251,21 @@ The following list was created by users like you. Feel free to add yours. The pr
       </td>
     </tr>
     <tr>
+      <td><code>dotnet-todo</code></td>
+      <td>
+        <p>
+          A .NET port of <a href-"http://todotxt.org/">http://todotxt.org/</a> that tries to remain faithful to the 
+		  command line and functionality of the original shell script wherever possible.
+        </p>
+        <p>
+          <strong>Project site:</strong> <a href="https://github.com/rprouse/dotnet-todo">GitHub</a>
+          <br />
+          <strong>Author:</strong> <a href="https://github.com/rprouse">@rprouse</a>
+        </p>
+        <code>dotnet tool install -g <a href="https://www.nuget.org/packages/dotnet-todo">dotnet-todo</a></code>
+      </td>
+    </tr>
+    <tr>
       <td><code>dotnet-tool-run</code></td>
       <td>
         <p>


### PR DESCRIPTION
This tool manages your todo list using the command line syntax and text file format of the shell script from http://todotxt.org/, originally from Life Hacker.