### PR TITLE
Change dotnet-tool-run to dotnex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1267,17 +1267,17 @@ The following list was created by users like you. Feel free to add yours. The pr
       </td>
     </tr>
     <tr>
-      <td><code>dotnet-tool-run</code></td>
+      <td><code>dotnex</code></td>
       <td>
         <p>
           A simple .NET tool to execute other dotnet tools without installing them globally or in a project.
         </p>
         <p>
-          <strong>Project site:</strong> <a href="https://github.com/piraces/dotnet-tool-run">GitHub</a>
+          <strong>Project site:</strong> <a href="https://github.com/piraces/dotnex">GitHub</a>
           <br />
           <strong>Author:</strong> <a href="https://github.com/piraces">@piraces</a>
         </p>
-        <code>dotnet tool install --global <a href="https://www.nuget.org/packages/dotnet-tool-run/">dotnet-tool-run</a></code>
+        <code>dotnet tool install --global <a href="https://www.nuget.org/packages/dotnex/">dotnex</a></code>
       </td>
     </tr>
     <tr>

--- a/README.md
+++ b/README.md
@@ -1267,20 +1267,6 @@ The following list was created by users like you. Feel free to add yours. The pr
       </td>
     </tr>
     <tr>
-      <td><code>dotnex</code></td>
-      <td>
-        <p>
-          A simple .NET tool to execute other dotnet tools without installing them globally or in a project.
-        </p>
-        <p>
-          <strong>Project site:</strong> <a href="https://github.com/piraces/dotnex">GitHub</a>
-          <br />
-          <strong>Author:</strong> <a href="https://github.com/piraces">@piraces</a>
-        </p>
-        <code>dotnet tool install --global <a href="https://www.nuget.org/packages/dotnex/">dotnex</a></code>
-      </td>
-    </tr>
-    <tr>
       <td><code>dotnet-tools-outdated</code></td>
       <td>
         <p>
@@ -1411,6 +1397,20 @@ The following list was created by users like you. Feel free to add yours. The pr
           <strong>Author:</strong> <a href="https://github.com/stulzq">@stulzq</a>
         </p>
         <code>dotnet tool install -g <a href="https://www.nuget.org/packages/dotnetrsa">dotnetrsa</a></code>
+      </td>
+    </tr>
+    <tr>
+      <td><code>dotnex</code></td>
+      <td>
+        <p>
+          A simple .NET tool to execute other dotnet tools without installing them globally or in a project.
+        </p>
+        <p>
+          <strong>Project site:</strong> <a href="https://github.com/piraces/dotnex">GitHub</a>
+          <br />
+          <strong>Author:</strong> <a href="https://github.com/piraces">@piraces</a>
+        </p>
+        <code>dotnet tool install --global <a href="https://www.nuget.org/packages/dotnex/">dotnex</a></code>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Hello, I am the author of the `dotnet-tool-run` tool.

I have renamed this tool to `dotnex` just a few minutes ago, and I would like to update this reference that I added originally to this repository 😃 

You can verify the change of the name in the following URLs:
https://www.nuget.org/packages/dotnex/
https://www.nuget.org/packages/dotnet-tool-run/ (note the legacy note and the suggested tool)
https://github.com/piraces/dotnex

Thank you in advance and sorry for the inconvenience.